### PR TITLE
Use RTL's waitFor() utility to get rid of "act()" related warnings

### DIFF
--- a/src/components/FollowersList/FollowersList.test.js
+++ b/src/components/FollowersList/FollowersList.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, wait, waitFor } from "@testing-library/react";
 import { act } from "react-dom/test-utils";
 
 import { withBrowserRouter } from "../helpers/helpers";
@@ -9,7 +9,7 @@ import axios from "axios";
 
 jest.mock("axios");
 
-describe("FollowersList", () => {
+describe("FollowersList", () => { 
   beforeEach(() => {
     axios.mockImplementation(() => ({
       get: jest.fn()
@@ -34,17 +34,18 @@ describe("FollowersList", () => {
       }
     })
   })
-  it("initially renders empty container with no items", () => {
+  it("initially renders empty container with no items", async () => {
     render(withBrowserRouter(<FollowersList />));
     const list = screen.getByTestId("followerslist-container");
     const items = list.querySelectorAll('.follower-item');
     expect(list).toBeInTheDocument();
     expect(items.length).toBe(0);
+    await waitFor(() => {}); // waitFor nothing, really
   })
 
   it("fetches list from API", async () => {
     render(withBrowserRouter(<FollowersList />));
-    expect(axios.get).toHaveBeenCalled();
+    await waitFor(() => expect(axios.get).toHaveBeenCalled());
   })
 
   it("renders items based on returned data", async () => {


### PR DESCRIPTION
Reference:
https://kentcdodds.com/blog/write-fewer-longer-tests

Wrap assertions in waitFor() so that the "act()" warnings don't happen. All of our requests are mocked so return immediately, so I think this is fine to do.
Except in the first test, where you don't really have anything to do with the result of the async call, so just waiting and ignoring the result.